### PR TITLE
Build using docker golang container when creating image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
+FROM golang:latest AS golang-builder
+
+COPY . /tmp/build/.
+
+# Avoid error where Go cannot determine current user:
+ENV USER=root
+
+# Build project:
+RUN make --directory /tmp/build build
+
 FROM        quay.io/prometheus/busybox:latest
 LABEL       maintainer="Maxime Wojtczak <maxime.wojtczak@zenika.com>"
 
-COPY snmp_notifier  /bin/snmp_notifier
+COPY --from=golang-builder /tmp/build/snmp_notifier /bin/snmp_notifier
 
 EXPOSE      9464
 ENTRYPOINT  [ "/bin/snmp_notifier" ]


### PR DESCRIPTION
To build: From project root...
`docker build -t snmp_notifier .`
- Builds the project using the latest golang compiler.
- Takes the resulting binary and adds it to docker image
