### PR TITLE
test util: allow bind of trap receiver to specific address

### DIFF
--- a/httpserver/http_server_test.go
+++ b/httpserver/http_server_test.go
@@ -141,7 +141,7 @@ var tests = []Test{
 }
 
 func TestPostAlerts(t *testing.T) {
-	server, channel, err := testutils.LaunchTrapReceiver(1164)
+	server, channel, err := testutils.LaunchTrapReceiver("127.0.0.1:1164")
 	if err != nil {
 		t.Fatal("Error while opening server:", err)
 	}

--- a/test/integration.go
+++ b/test/integration.go
@@ -14,7 +14,6 @@
 package test
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -31,9 +30,9 @@ func (trapListener *testTrapListener) OnTRAP(trap *snmpgo.TrapRequest) {
 }
 
 // LaunchTrapReceiver provides a SNMP server for testing purposes
-func LaunchTrapReceiver(port int32) (*snmpgo.TrapServer, chan *snmpgo.TrapRequest, error) {
+func LaunchTrapReceiver(addr string) (*snmpgo.TrapServer, chan *snmpgo.TrapRequest, error) {
 	trapServer, err := snmpgo.NewTrapServer(snmpgo.ServerArguments{
-		LocalAddr: fmt.Sprintf("127.0.0.1:%d", port),
+		LocalAddr: addr,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestReadV2Traps(t *testing.T) {
 
-	server, channel, err := LaunchTrapReceiver(1162)
+	server, channel, err := LaunchTrapReceiver("127.0.0.1:1162")
 	if err != nil {
 		t.Fatal("Error while opening server", err)
 	}
@@ -44,7 +44,7 @@ func TestReadV2Traps(t *testing.T) {
 
 func TestFindTrap(t *testing.T) {
 
-	server, channel, err := LaunchTrapReceiver(1162)
+	server, channel, err := LaunchTrapReceiver("127.0.0.1:1162")
 	if err != nil {
 		t.Fatal("Error while opening server", err)
 	}

--- a/trapsender/trap_sender_test.go
+++ b/trapsender/trap_sender_test.go
@@ -118,7 +118,7 @@ func TestSend(t *testing.T) {
 		},
 	}
 
-	server, channel, err := testutils.LaunchTrapReceiver(1163)
+	server, channel, err := testutils.LaunchTrapReceiver("127.0.0.1:1163")
 	if err != nil {
 		t.Fatal("Error while opening server:", err)
 	}


### PR DESCRIPTION
by allowing bind on any address, this change makes the trap receiver reusable for integration tests with alertmanager, for example, or in other projects.

