### PR TITLE
When using SNMPv3, userName always needs to be set.

### DIFF
--- a/trapsender/trap_sender.go
+++ b/trapsender/trap_sender.go
@@ -141,6 +141,7 @@ func (trapSender TrapSender) connect() (*snmpgo.SNMP, error) {
 
 	if trapSender.configuration.SNMPVersion == "V3" {
 		snmpArguments.Version = snmpgo.V3
+		snmpArguments.UserName = trapSender.configuration.SNMPAuthenticationUsername
 
 		if trapSender.configuration.SNMPAuthenticationEnabled && trapSender.configuration.SNMPPrivateEnabled {
 			snmpArguments.SecurityLevel = snmpgo.AuthPriv
@@ -157,7 +158,6 @@ func (trapSender TrapSender) connect() (*snmpgo.SNMP, error) {
 
 		if trapSender.configuration.SNMPAuthenticationEnabled {
 			snmpArguments.AuthProtocol = snmpgo.AuthProtocol(trapSender.configuration.SNMPAuthenticationProtocol)
-			snmpArguments.UserName = trapSender.configuration.SNMPAuthenticationUsername
 			snmpArguments.AuthPassword = trapSender.configuration.SNMPAuthenticationPassword
 		}
 


### PR DESCRIPTION
See [RFC3414 section 3.1](https://tools.ietf.org/html/rfc3414#section-3.1), point 7: userName is set into the trap even when securityLevel = NoAuthNoPriv
Dependency "github.com/k-sone/snmpgo" is returning an error when username is not set

Currently, the parameter *--snmp.authentication-username* is used to set the SNMPv3 username. Since the username is not really related to the authentication, I think this parameter should be modified; either renamed to something like *--snmp.security-name* or documentation updated to reflect to what it maps to.