### PR TITLE
Add multi targets

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -44,7 +44,7 @@ func ParseConfiguration(args []string) (*SNMPNotifierConfiguration, log.Logger, 
 		alertDefaultSeverity = application.Flag("alert.default-severity", "The alert severity if none is provided via labels.").Default("critical").String()
 
 		snmpVersion                 = application.Flag("snmp.version", "SNMP version. V2c and V3 are currently supported.").Default("V2c").HintOptions("V2c", "V3").Enum("V2c", "V3")
-		snmpDestination             = application.Flag("snmp.destination", "SNMP trap server destination.").Default("127.0.0.1:162").TCP()
+		snmpDestination             = application.Flag("snmp.destination", "SNMP trap server destination.").Default("127.0.0.1:162").TCPList()
 		snmpRetries                 = application.Flag("snmp.retries", "SNMP number of retries").Default("1").Uint()
 		snmpTrapOidLabel            = application.Flag("snmp.trap-oid-label", "Label where to find the trap OID.").Default("oid").String()
 		snmpDefaultOid              = application.Flag("snmp.trap-default-oid", "Trap OID to send if none is found in the alert labels.").Default("1.3.6.1.4.1.98789.0.1").String()
@@ -119,9 +119,14 @@ func ParseConfiguration(args []string) (*SNMPNotifierConfiguration, log.Logger, 
 
 	isV2c := *snmpVersion == "V2c"
 
+	snmpDestinations := []string{}
+	for _, destination := range *snmpDestination {
+		snmpDestinations = append(snmpDestinations, destination.String())
+	}
+
 	trapSenderConfiguration := trapsender.Configuration{
 		SNMPVersion:         *snmpVersion,
-		SNMPDestination:     (*snmpDestination).String(),
+		SNMPDestination:     snmpDestinations,
 		SNMPRetries:         *snmpRetries,
 		DescriptionTemplate: *descriptionTemplate,
 		ExtraFieldTemplates: extraFieldTemplates,

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -246,7 +246,7 @@ func TestParseConfiguration(t *testing.T) {
 		}
 		elements := strings.Split(test.CommandLine, " ")
 		log.Print(elements)
-		configuration, err := ParseConfiguration(elements)
+		configuration, _, err := ParseConfiguration(elements)
 		log.Print(elements)
 
 		if test.ExpectError && err == nil {

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -51,7 +51,7 @@ var tests = []Test{
 			},
 			trapsender.Configuration{
 				SNMPVersion:         "V2c",
-				SNMPDestination:     "127.0.0.1:162",
+				SNMPDestination:     []string{"127.0.0.1:162"},
 				SNMPRetries:         1,
 				SNMPTimeout:         10 * time.Second,
 				SNMPCommunity:       "public",
@@ -78,7 +78,7 @@ var tests = []Test{
 			},
 			trapsender.Configuration{
 				SNMPVersion:         "V2c",
-				SNMPDestination:     "127.0.0.2:163",
+				SNMPDestination:     []string{"127.0.0.2:163"},
 				SNMPRetries:         4,
 				SNMPTimeout:         5 * time.Second,
 				SNMPCommunity:       "private",
@@ -105,7 +105,7 @@ var tests = []Test{
 			},
 			trapsender.Configuration{
 				SNMPVersion:         "V3",
-				SNMPDestination:     "127.0.0.2:163",
+				SNMPDestination:     []string{"127.0.0.2:163"},
 				SNMPRetries:         4,
 				SNMPTimeout:         5 * time.Second,
 				ExtraFieldTemplates: make(map[string]template.Template),
@@ -132,7 +132,7 @@ var tests = []Test{
 			},
 			trapsender.Configuration{
 				SNMPVersion:                "V3",
-				SNMPDestination:            "127.0.0.2:163",
+				SNMPDestination:            []string{"127.0.0.2:163"},
 				SNMPRetries:                4,
 				SNMPTimeout:                5 * time.Second,
 				SNMPAuthenticationEnabled:  true,
@@ -163,7 +163,7 @@ var tests = []Test{
 			},
 			trapsender.Configuration{
 				SNMPVersion:                "V3",
-				SNMPDestination:            "127.0.0.2:163",
+				SNMPDestination:            []string{"127.0.0.2:163"},
 				SNMPRetries:                4,
 				SNMPTimeout:                5 * time.Second,
 				SNMPAuthenticationUsername: "username_v3",
@@ -192,7 +192,7 @@ var tests = []Test{
 			},
 			trapsender.Configuration{
 				SNMPVersion:                "V3",
-				SNMPDestination:            "127.0.0.2:163",
+				SNMPDestination:            []string{"127.0.0.2:163"},
 				SNMPRetries:                4,
 				SNMPTimeout:                5 * time.Second,
 				SNMPPrivateEnabled:         true,

--- a/httpserver/http_server_test.go
+++ b/httpserver/http_server_test.go
@@ -223,7 +223,7 @@ func launchHTTPServer(t *testing.T, test Test) *http.Server {
 	}
 
 	trapSenderConfiguration := trapsender.Configuration{
-		snmpDestination,
+		[]string{snmpDestination},
 		1,
 		"V2c",
 		5 * time.Second,

--- a/httpserver/http_server_test.go
+++ b/httpserver/http_server_test.go
@@ -30,6 +30,8 @@ import (
 	testutils "github.com/maxwo/snmp_notifier/test"
 
 	"text/template"
+
+	"github.com/prometheus/common/promlog"
 )
 
 var dummyDescriptionTemplate = `{{ range $key, $value := .Alerts }}Alert name: {{ $value.Labels.alertname }}
@@ -242,7 +244,10 @@ func launchHTTPServer(t *testing.T, test Test) *http.Server {
 	trapSender := trapsender.New(trapSenderConfiguration)
 
 	httpServerConfiguration := Configuration{":9465"}
-	httpServer := New(httpServerConfiguration, alertParser, trapSender).Configure()
+
+	promlogConfig := promlog.Config{}
+	logger := promlog.New(&promlogConfig)
+	httpServer := New(httpServerConfiguration, alertParser, trapSender, logger).Configure()
 	go func() {
 		httpServer.ListenAndServe()
 	}()

--- a/trapsender/trap_sender_test.go
+++ b/trapsender/trap_sender_test.go
@@ -51,7 +51,7 @@ func TestSend(t *testing.T) {
 			dummyDescriptionTemplate,
 			1163,
 			&Configuration{
-				"127.0.0.1:1163",
+				[]string{"127.0.0.1:1163"},
 				1,
 				"V2c",
 				5 * time.Second,
@@ -77,7 +77,7 @@ func TestSend(t *testing.T) {
 			invalidDescriptionTemplate,
 			1163,
 			&Configuration{
-				"127.0.0.1:1163",
+				[]string{"127.0.0.1:1163"},
 				1,
 				"V2c",
 				5 * time.Second,
@@ -103,7 +103,7 @@ func TestSend(t *testing.T) {
 			dummyDescriptionTemplate,
 			1166,
 			&Configuration{
-				"127.0.0.1:1166",
+				[]string{"127.0.0.1:1166"},
 				1,
 				"V3",
 				5 * time.Second,


### PR DESCRIPTION
Make the command line parameter `--snmp.destination` repeatable. Use the same configuration for each additional target.