### PR TITLE
alertparser: always send alerts

### DIFF
--- a/alertparser/alert_parser.go
+++ b/alertparser/alert_parser.go
@@ -56,11 +56,9 @@ func (alertParser AlertParser) Parse(alertsData types.AlertsData) (*types.AlertB
 		if _, found := alertGroups[key]; !found {
 			alertGroups[key] = &types.AlertGroup{OID: *oid, GroupID: groupID, Severity: alertParser.getLowestSeverity(), Alerts: []types.Alert{}}
 		}
-		if alert.Status == "firing" {
-			err = alertParser.addAlertToGroup(alertGroups[key], alert)
-			if err != nil {
-				return nil, err
-			}
+		err = alertParser.addAlertToGroup(alertGroups[key], alert)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/alertparser/test_mixed_bucket.json
+++ b/alertparser/test_mixed_bucket.json
@@ -58,8 +58,23 @@
     "1.3.6.1.4.1.666.0.10.1.1.1.1.1[environment=production,label=test]": {
       "OID": "1.3.6.1.4.1.666.0.10.1.1.1.1.1",
       "GroupID": "environment=production,label=test",
-      "Severity": "info",
-      "Alerts": []
+      "Severity": "warning",
+      "Alerts": [
+        {
+          "status": "resolved",
+          "labels": {
+            "environment": "production",
+            "label": "test",
+            "severity": "warning",
+            "alertname": "TestAlert",
+            "oid": "1.3.6.1.4.1.666.0.10.1.1.1.1.1"
+          },
+          "annotations": {
+            "summary": "this is the random summary",
+            "description": "this is the description of the alert"
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Always call `addAlertToGroup`, not only if the alert status is `firing`.
This makes sure the alert labels are also part of a resolved alert.

Fixes #76
Fixes #101